### PR TITLE
Update datadog agent image settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 datadog:
   build: . 
   restart: "on-failure"
-  privileged: true
   volumes:
     - "/var/run/docker.sock:/var/run/docker.sock"
-    - "/proc/mounts:/host/proc/mounts:ro"
+    - "/proc/:/host/proc/:ro"
     - "/sys/fs/cgroup:/host/sys/fs/cgroup:ro"
   environment:
     - "API_KEY=YOUR-API-KEY-HERE"


### PR DESCRIPTION
Starting with agent 5.5.0, the whole /proc needs to be mounted in the container.
Similarly, the privileged flag is not useful anymore.
